### PR TITLE
[feat] Add Docker support for standalone libp2p nodes with Python example

### DIFF
--- a/c-abi-libp2p/examples/python/Dockerfile
+++ b/c-abi-libp2p/examples/python/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# Build stage for the Rust shared library
+FROM rust:1.91 AS builder
+
+WORKDIR /usr/src/app
+
+# Copy the C-ABI project
+# We assume the build context is the root of the repo
+COPY c-abi-libp2p ./c-abi-libp2p
+
+WORKDIR /usr/src/app/c-abi-libp2p
+
+# Build the shared library in release mode
+RUN cargo build --release
+
+# Runtime stage
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Copy the compiled shared library from the builder stage
+COPY --from=builder /usr/src/app/c-abi-libp2p/target/release/libcabi_rust_libp2p.so /usr/local/lib/
+
+# Set the environment variable so the Python script finds the library
+ENV FIDONEXT_C_ABI=/usr/local/lib/libcabi_rust_libp2p.so
+ENV RUST_LOG=info,peer=info,ffi=info
+
+# Copy the Python example scripts
+COPY c-abi-libp2p/examples/python/ping_standalone_nodes.py .
+
+# Entrypoint
+ENTRYPOINT ["python3", "ping_standalone_nodes.py"]
+

--- a/c-abi-libp2p/examples/python/README.md
+++ b/c-abi-libp2p/examples/python/README.md
@@ -64,3 +64,24 @@ Small `ctypes` script that:
   cd /home/georgeb/fidonext-core/c-abi-libp2p
   RUST_LOG="info,peer=debug,ffi=debug" python3 examples/python/ping_two_nodes.py --use-quic
   ```
+
+## Docker Example (Standalone Nodes)
+
+To run two separate nodes in Docker containers that communicate over a bridge network:
+
+1. Navigate to the python examples directory:
+   ```bash
+   cd c-abi-libp2p/examples/python
+   ```
+
+2. Run with Docker Compose:
+   ```bash
+   docker-compose up --build
+   ```
+
+   This will:
+   - Build the Rust library in a Docker container.
+   - Create two containers: `libp2p-listener` (at 172.28.0.2) and `libp2p-dialer` (at 172.28.0.3).
+   - The dialer will connect to the listener and exchange pings.
+
+   You can see the output of both containers in the terminal. Use Ctrl+C to stop.

--- a/c-abi-libp2p/examples/python/docker-compose.yml
+++ b/c-abi-libp2p/examples/python/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  listener:
+    build:
+      context: ../../../
+      dockerfile: c-abi-libp2p/examples/python/Dockerfile
+    image: libp2p-python-example
+    container_name: libp2p-listener
+    command: ["--mode", "listen", "--addr", "/ip4/0.0.0.0/tcp/41000"]
+    networks:
+      libp2p_net:
+        ipv4_address: 172.28.0.2
+
+  dialer:
+    build:
+      context: ../../../
+      dockerfile: c-abi-libp2p/examples/python/Dockerfile
+    image: libp2p-python-example
+    container_name: libp2p-dialer
+    command: ["--mode", "dial", "--addr", "/ip4/172.28.0.2/tcp/41000"]
+    depends_on:
+      - listener
+    networks:
+      libp2p_net:
+        ipv4_address: 172.28.0.3
+
+networks:
+  libp2p_net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16
+

--- a/c-abi-libp2p/examples/python/ping_standalone_nodes.py
+++ b/c-abi-libp2p/examples/python/ping_standalone_nodes.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Standalone node example via the C ABI.
+
+This script runs a single libp2p node that can either listen or dial.
+Designed to be run in separate processes/containers.
+"""
+
+import argparse
+import ctypes
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+# Setup similar to ping_two_nodes.py
+try:
+    # Try to determine project root relative to this script
+    # This works in the repo structure: .../pheonx-core/c-abi-libp2p/examples/python/script.py
+    repo_root = Path(__file__).resolve().parents[3]
+    DEFAULT_LIB = repo_root / "c-abi-libp2p" / "target" / "debug" / "libcabi_rust_libp2p.so"
+except IndexError:
+    # Fallback for shallow directory structures (e.g. inside Docker /app/script.py)
+    # In this case, we rely on FIDONEXT_C_ABI being set.
+    DEFAULT_LIB = Path("/nonexistent/lib.so")
+
+# In Docker, we will set this env var to the installed location
+LIB_PATH = Path(os.environ.get("FIDONEXT_C_ABI", DEFAULT_LIB))
+
+os.environ.setdefault("RUST_LOG", "info,peer=info,ffi=info")
+
+if not LIB_PATH.exists():
+    print(f"Shared library not found at {LIB_PATH}.", file=sys.stderr)
+    print("Run `cargo build` in c-abi-libp2p first or set FIDONEXT_C_ABI.", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    lib = ctypes.CDLL(str(LIB_PATH))
+except OSError as e:
+    print(f"Failed to load library {LIB_PATH}: {e}", file=sys.stderr)
+    sys.exit(1)
+
+# Status codes exported from the ABI.
+CABI_STATUS_SUCCESS = 0
+CABI_STATUS_NULL_POINTER = 1
+CABI_STATUS_INVALID_ARGUMENT = 2
+
+# Define signatures
+lib.cabi_init_tracing.restype = ctypes.c_int
+lib.cabi_node_new.argtypes = [ctypes.c_bool]
+lib.cabi_node_new.restype = ctypes.c_void_p
+lib.cabi_node_listen.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+lib.cabi_node_listen.restype = ctypes.c_int
+lib.cabi_node_dial.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+lib.cabi_node_dial.restype = ctypes.c_int
+lib.cabi_node_free.argtypes = [ctypes.c_void_p]
+lib.cabi_node_free.restype = None
+
+def _check(status: int, context: str) -> None:
+    if status == CABI_STATUS_SUCCESS:
+        return
+    if status == CABI_STATUS_NULL_POINTER:
+        reason = "null pointer passed into ABI"
+    elif status == CABI_STATUS_INVALID_ARGUMENT:
+        reason = "invalid argument (multiaddr or UTF-8)"
+    else:
+        reason = "internal error – inspect Rust logs for details"
+    raise RuntimeError(f"{context} failed: {reason} (status={status})")
+
+class Node:
+    def __init__(self, use_quic: bool = False) -> None:
+        pointer = lib.cabi_node_new(ctypes.c_bool(use_quic))
+        if not pointer:
+            raise RuntimeError("cabi_node_new returned NULL, check Rust logs")
+        self._ptr = ctypes.c_void_p(pointer)
+
+    def listen(self, multiaddr: str) -> None:
+        print(f"Attempting to listen on {multiaddr}...")
+        _check(
+            lib.cabi_node_listen(self._ptr, multiaddr.encode("utf-8")),
+            f"listen({multiaddr})",
+        )
+        print(f"Listening on {multiaddr}")
+
+    def dial(self, multiaddr: str) -> None:
+        print(f"Attempting to dial {multiaddr}...")
+        _check(
+            lib.cabi_node_dial(self._ptr, multiaddr.encode("utf-8")),
+            f"dial({multiaddr})",
+        )
+        print(f"Dialed {multiaddr}")
+
+    def close(self) -> None:
+        if self._ptr:
+            print("Closing node...")
+            lib.cabi_node_free(self._ptr)
+            self._ptr = None
+
+    def __del__(self) -> None:
+        self.close()
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a standalone libp2p node via the C ABI."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["listen", "dial"],
+        required=True,
+        help="Mode to run the node in.",
+    )
+    parser.add_argument(
+        "--addr",
+        required=True,
+        help="Multiaddr to listen on (if mode=listen) or dial (if mode=dial).",
+    )
+    parser.add_argument(
+        "--use-quic",
+        action="store_true",
+        help="Enable the QUIC transport.",
+    )
+    return parser.parse_args()
+
+def main() -> None:
+    args = parse_args()
+    
+    # Initialize tracing once
+    _check(lib.cabi_init_tracing(), "init tracing")
+
+    node = Node(use_quic=args.use_quic)
+    
+    # Handle graceful shutdown
+    running = True
+    def signal_handler(sig, frame):
+        nonlocal running
+        print("\nReceived signal, shutting down...")
+        running = False
+    
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        if args.mode == "listen":
+            node.listen(args.addr)
+            print("Node is ready. Press Ctrl+C to stop.")
+            while running:
+                time.sleep(1)
+        elif args.mode == "dial":
+            # For dialer, we might want to retry if the listener isn't ready yet
+            max_retries = 10
+            for i in range(max_retries):
+                try:
+                    node.dial(args.addr)
+                    break
+                except RuntimeError as e:
+                    if i == max_retries - 1:
+                        raise
+                    print(f"Dial failed, retrying in 1s ({i+1}/{max_retries})...")
+                    time.sleep(1)
+            
+            print("Connection established. Maintaining connection...")
+            while running:
+                time.sleep(1)
+                
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        node.close()
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
- Introduced a Dockerfile to build a Python environment that utilizes a Rust shared library.
- Added a docker-compose.yml file to orchestrate two containers: a listener and a dialer.
- Implemented a Python script (ping_standalone_nodes.py) to demonstrate communication between the nodes.
- Updated README.md with instructions for running the example using Docker.