### PR TITLE
Bug #39. Changed heartbeat, message auth of gossipsub

### DIFF
--- a/c-abi-libp2p/src/transport/libp2p.rs
+++ b/c-abi-libp2p/src/transport/libp2p.rs
@@ -170,8 +170,6 @@ impl TransportConfig {
         let autonat_config = autonat::Config::default();
 
         let gossipsub_config = gossipsub::ConfigBuilder::default()
-            .validation_mode(gossipsub::ValidationMode::None)
-            .heartbeat_interval(Duration::from_secs(5))
             .build()
             .expect("valid gossipsub config");
 


### PR DESCRIPTION
closing #39
Fixed gossipsub configuration:

- Changed the heartbeat, reducing to initial 1s (may be can lower this to gain speed)
- Changed Authenticity needed for the user to send message. PeerId + sequence number.
[Heartbeat interval](https://docs.rs/libp2p/latest/libp2p/gossipsub/struct.ConfigBuilder.html#method.heartbeat_interval)
[ValidationMode](https://docs.rs/libp2p/latest/libp2p/gossipsub/enum.ValidationMode.html)
