### PR TITLE
Small refactor for single node_new func

### DIFF
--- a/c-abi-libp2p/examples/cpp/ping.cpp
+++ b/c-abi-libp2p/examples/cpp/ping.cpp
@@ -153,7 +153,7 @@ string statusMessage(int status)
 bool loadAbi(LibHandle lib, CabiRustLibp2p& abi)
 {
   abi.InitTracing = reinterpret_cast<InitTracingFunc>(GET_PROC(lib, "cabi_init_tracing"));
-  abi.NewNode = reinterpret_cast<NewNodeFunc>(GET_PROC(lib, "cabi_node_new_with_relay_bootstrap_and_seed"));
+  abi.NewNode = reinterpret_cast<NewNodeFunc>(GET_PROC(lib, "cabi_node_new"));
   abi.ListenNode = reinterpret_cast<ListenNodeFunc>(GET_PROC(lib, "cabi_node_listen"));
   abi.DialNode = reinterpret_cast<DialNodeFunc>(GET_PROC(lib, "cabi_node_dial"));
   abi.AutonatStatus = reinterpret_cast<AutonatStatusFunc>(GET_PROC(lib, "cabi_autonat_status"));

--- a/c-abi-libp2p/src/lib.rs
+++ b/c-abi-libp2p/src/lib.rs
@@ -220,56 +220,9 @@ pub extern "C" fn cabi_autonat_status(handle: *mut CabiNodeHandle) -> c_int {
 }
 
 #[no_mangle]
-/// C-ABI. Creates a new node instance and returns its handle
-pub extern "C" fn cabi_node_new(use_quic: bool) -> *mut CabiNodeHandle {
-    cabi_node_new_with_relay_bootstrap_and_seed(
-        use_quic,
-        false,
-        std::ptr::null(),
-        0,
-        std::ptr::null(),
-        0,
-    )
-}
-
-#[no_mangle]
-/// C-ABI. Creates a new node instance and returns its handle with optional relay hop mode
-pub extern "C" fn cabi_node_new_with_relay(
-    use_quic: bool,
-    enable_relay_hop: bool,
-) -> *mut CabiNodeHandle {
-    cabi_node_new_with_relay_bootstrap_and_seed(
-        use_quic,
-        enable_relay_hop,
-        std::ptr::null(),
-        0,
-        std::ptr::null(),
-        0,
-    )
-}
-
-#[no_mangle]
-/// C-ABI. Creates a new node instance and returns its handle with optional relay hop mode and bootstrap peers
-pub extern "C" fn cabi_node_new_with_relay_and_bootstrap(
-    use_quic: bool,
-    enable_relay_hop: bool,
-    bootstrap_peers: *const *const c_char,
-    bootstrap_peers_len: usize,
-) -> *mut CabiNodeHandle {
-    cabi_node_new_with_relay_bootstrap_and_seed(
-        use_quic,
-        enable_relay_hop,
-        bootstrap_peers,
-        bootstrap_peers_len,
-        std::ptr::null(),
-        0,
-    )
-}
-
-#[no_mangle]
 /// C-ABI. Creates a new node instance and returns its handle with optional relay hop mode, bootstrap peers,
 /// and a fixed Ed25519 identity seed.
-pub extern "C" fn cabi_node_new_with_relay_bootstrap_and_seed(
+pub extern "C" fn cabi_node_new(
     use_quic: bool,
     enable_relay_hop: bool,
     bootstrap_peers: *const *const c_char,


### PR DESCRIPTION
now we've got single fucntion to start creating node from. cabi_node_new() with params.
C++ expaple also fixed