### PR TITLE
Update Docker Compose and Dockerfile for improved network configuration

### DIFF
--- a/c-abi-libp2p/examples/cpp/Dockerfile
+++ b/c-abi-libp2p/examples/cpp/Dockerfile
@@ -33,9 +33,14 @@ RUN cmake -S . -B build-docker -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build build-docker --config Release -j"$(nproc)"
 
 
-FROM --platform=linux/amd64 gcr.io/distroless/cc-debian12 AS runtime
-
+FROM --platform=linux/amd64 debian:bookworm-slim AS runtime
 WORKDIR /app
+
+# Required for the dynamically-linked Rust .so and C++ binary
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgcc-s1 \
+    iproute2 \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=rust_builder /build/target/x86_64-unknown-linux-gnu/release/libcabi_rust_libp2p.so /app/
 COPY --from=cpp_builder /build/build-docker/ping /app/

--- a/c-abi-libp2p/examples/cpp/docker-compose.yml
+++ b/c-abi-libp2p/examples/cpp/docker-compose.yml
@@ -59,11 +59,11 @@ services:
     sysctls:
       net.ipv4.ip_forward: "1"
     environment:
-      INTERNAL_IP: 192.168.0.2   # netC side
+      INTERNAL_IP: 192.168.0.3   # netC side
       EXTERNAL_IP: 10.0.0.3   # netB side
     networks:
       netC:
-        ipv4_address: 192.168.0.2
+        ipv4_address: 192.168.0.3
       netB:
         ipv4_address: 10.0.0.3
     command:
@@ -130,7 +130,15 @@ services:
     networks:
       netA:
         ipv4_address: 172.20.0.10
-    command: ["/app/ping", "--listen", "/ip4/0.0.0.0/tcp/41001", "--bootstrap", "/ip4/10.0.0.10/tcp/41000/p2p/12D3KooWSNqRTV2JccvWYTxtDtXUk9Y1m7EcGLy65eRN1qSrDkdp", "--seed-phrase", "peer-a", "--target", "/ip4/192.168.0.10/tcp/41000/p2p/12D3KooWD5NqycxsN1Dx8P7nZcH8SdhT1TC38iHiMbRd599qpzr7"]
+    command:
+      - sh
+      - -exc
+      - |
+        ip route add 10.0.0.0/24 via 172.20.0.2
+        exec /app/ping --listen /ip4/0.0.0.0/tcp/41001 \
+          --bootstrap /ip4/10.0.0.10/tcp/41000/p2p/12D3KooWSNqRTV2JccvWYTxtDtXUk9Y1m7EcGLy65eRN1qSrDkdp \
+          --seed-phrase peer-a \
+          --target /ip4/192.168.0.10/tcp/41000/p2p/12D3KooWD5NqycxsN1Dx8P7nZcH8SdhT1TC38iHiMbRd599qpzr7
     tty: true
     stdin_open: true
 
@@ -148,7 +156,15 @@ services:
     networks:
       netC:
         ipv4_address: 192.168.0.10
-    command: ["/app/ping", "--listen", "/ip4/0.0.0.0/tcp/41001", "--bootstrap", "/ip4/10.0.0.10/tcp/41000/p2p/12D3KooWSNqRTV2JccvWYTxtDtXUk9Y1m7EcGLy65eRN1qSrDkdp", "--seed-phrase", "peer-b", "--target", "/ip4/172.20.0.10/tcp/41000/p2p/12D3KooWKDAxUshAR3XqKiy9pgo1PCrSMHWvNfAopdTthBApdgDG"]
+    command:
+      - sh
+      - -exc
+      - |
+        ip route add 10.0.0.0/24 via 192.168.0.3
+        exec /app/ping --listen /ip4/0.0.0.0/tcp/41001 \
+          --bootstrap /ip4/10.0.0.10/tcp/41000/p2p/12D3KooWSNqRTV2JccvWYTxtDtXUk9Y1m7EcGLy65eRN1qSrDkdp \
+          --seed-phrase peer-b \
+          --target /ip4/172.20.0.10/tcp/41000/p2p/12D3KooWKDAxUshAR3XqKiy9pgo1PCrSMHWvNfAopdTthBApdgDG
     tty: true
     stdin_open: true
 


### PR DESCRIPTION
- Changed internal IP addresses in docker-compose.yml to 192.168.0.3 for netC services.
- Updated command execution in docker-compose.yml to include routing setup for NAT services.
- Modified Dockerfile to use debian:bookworm-slim as the base image and added necessary dependencies for runtime.