### PR TITLE
Add Android build support

### DIFF
--- a/.github/workflows/libcabi-build-and-release.yml
+++ b/.github/workflows/libcabi-build-and-release.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   RUST_TOOLCHAIN: "1.91.0"
+  ANDROID_NDK_VERSION: "27.3.13750724"
 
 jobs:
   build:
@@ -30,10 +31,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Java (for Android SDK tools)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
       - name: Install Rust ${{ env.RUST_TOOLCHAIN }}
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
       - name: Install system dependencies
         run: |
@@ -50,7 +60,17 @@ jobs:
           rustup target add \
             x86_64-unknown-linux-gnu \
             aarch64-unknown-linux-gnu \
-            x86_64-pc-windows-gnu
+            x86_64-pc-windows-gnu \
+            aarch64-linux-android
+
+      - name: Install Android NDK
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager "ndk;${{ env.ANDROID_NDK_VERSION }}"
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${{ env.ANDROID_NDK_VERSION }}" >> "${GITHUB_ENV}"
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
 
       - name: Build Linux (GNU)
         run: cargo build --release --target x86_64-unknown-linux-gnu
@@ -60,6 +80,9 @@ jobs:
 
       - name: Build Windows (GNU)
         run: cargo build --release --target x86_64-pc-windows-gnu
+
+      - name: Build Android (arm64-v8a)
+        run: cargo ndk -t arm64-v8a build --release
 
       - name: Run tests
         run: cargo test --release --verbose
@@ -81,6 +104,10 @@ jobs:
           # Windows x86_64 (GNU)
           cp target/x86_64-pc-windows-gnu/release/cabi_rust_libp2p.dll \
             "${OUTPUT_DIR}/cabi_rust_libp2p-windows-x86_64.dll" 2>/dev/null || true
+
+          # Android arm64-v8a
+          cp target/aarch64-linux-android/release/libcabi_rust_libp2p.so \
+            "${OUTPUT_DIR}/libcabi_rust_libp2p-android-arm64-v8a.so" 2>/dev/null || true
 
           # Header
           cargo build

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,19 +15,38 @@ RUN apt-get update && \
         gcc-aarch64-linux-gnu \
         gcc-mingw-w64 \
         libc6-dev-arm64-cross \
-        lld && \
+        lld \
+        openjdk-21-jre-headless \
+        unzip \
+        wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cross-compilation targets
 RUN rustup target add \
         x86_64-unknown-linux-gnu \
         aarch64-unknown-linux-gnu \
-        x86_64-pc-windows-gnu
+        x86_64-pc-windows-gnu \
+        aarch64-linux-android
 
 ENV CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
     AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+ENV ANDROID_NDK_VERSION=27.3.13750724
+
+# Android (NDK) setup for building arm64-v8a
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV PATH="${PATH}:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin"
+RUN mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools" && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O /tmp/cmdline-tools.zip && \
+    unzip -q /tmp/cmdline-tools.zip -d "${ANDROID_SDK_ROOT}/cmdline-tools" && \
+    mv "${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/latest" && \
+    rm -f /tmp/cmdline-tools.zip && \
+    yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null && \
+    sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" "ndk;${ANDROID_NDK_VERSION}"
+ENV ANDROID_NDK_HOME="${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}"
+RUN cargo install cargo-ndk --locked
         
 
 # Set working directory
@@ -46,6 +65,8 @@ RUN echo "Building for Linux (ARM64)..."
 RUN cargo build --release --target aarch64-unknown-linux-gnu
 RUN echo "Building for Windows (GNU)..."
 RUN cargo build --release --target x86_64-pc-windows-gnu
+RUN echo "Building for Android (arm64-v8a)..."
+RUN cargo ndk -t arm64-v8a build --release
 
 # Test stage - runs tests for native platform (default final stage)
 FROM builder AS test
@@ -58,7 +79,8 @@ WORKDIR /app/c-abi-libp2p
 # Create output directory structure
 RUN mkdir -p /output/linux-x86_64-gnu \
     && mkdir -p /output/linux-aarch64 \
-    && mkdir -p /output/windows-x86_64-gnu
+    && mkdir -p /output/windows-x86_64-gnu \
+    && mkdir -p /output/android-arm64-v8a
 
 # Copy Linux GNU build
 RUN cp target/x86_64-unknown-linux-gnu/release/libcabi_rust_libp2p.so /output/linux-x86_64-gnu/ 2>/dev/null || true
@@ -68,6 +90,9 @@ RUN cp target/aarch64-unknown-linux-gnu/release/libcabi_rust_libp2p.so /output/l
 
 # Copy Windows GNU build
 RUN cp target/x86_64-pc-windows-gnu/release/cabi_rust_libp2p.dll /output/windows-x86_64-gnu/ 2>/dev/null || true
+
+# Copy Android arm64-v8a build
+RUN cp target/aarch64-linux-android/release/libcabi_rust_libp2p.so /output/android-arm64-v8a/ 2>/dev/null || true
 
 # Generate C header file
 RUN cargo build && \


### PR DESCRIPTION
- Added Android NDK installation and setup in Dockerfile for arm64-v8a target.
- Updated CI workflow to include Android SDK and NDK setup, ensuring compatibility with the new build targets.
- Modified build process to include Android artifacts in the output directory.